### PR TITLE
add MSRV of 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = []
 repository = "https://github.com/JosephLenton/reserve-port"
 documentation = "https://docs.rs/reserve-port/latest/reserve-port"
 readme = "README.md"
+rust-version = "1.80"
 
 [dependencies]
 thiserror = "2.0"


### PR DESCRIPTION
reserve-port uses LazyLock which requires Rust 1.80.  I'm using 1.79 in a project and so reserve-port produces a compilation error.  Adding this field to the cargo manifest will make the version requirement more explicit and easier to diagnose than the current error:

```
error[E0658]: use of unstable library feature 'lazy_cell'
 --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/reserve-port-2.2.0/src/reserved_port_finder.rs:9:5
  |
9 | use std::sync::LazyLock;
  |     ^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #109736 <https://github.com/rust-lang/rust/issues/109736> for more information
```

FWIW, I'm using axum and wanted to use axum-test, but it requires reserve-port which in turn requires Rust 1.80 which I currently can't use, being pinned to 1.79.